### PR TITLE
Refactor : styling teams page to ensure responsiveness

### DIFF
--- a/app/views/departments/index.html.erb
+++ b/app/views/departments/index.html.erb
@@ -8,8 +8,8 @@
   <main class="flex flex-col overflow-y-auto px-5">
     <section class="grid md:grid-cols-2 xl:grid-cols-4 gap-6 py-6" >
       <% @departments.each do |d| %>
-        <%= link_to department_path(d), class: "btn-ouline box flex items-center p-8 bg-white shadow rounded-lg", data: { turbo_frame: "modal"} do %>
-          <div class="inline-flex flex-shrink-0 items-center justify-center h-16 w-16 text-dark-purple bg-light-purple rounded-full mr-6">
+        <%= link_to department_path(d), class: "btn-ouline box flex items-center p-8 bg-white  shadow-lg hover:shadow-xl drop-shadow-xl rounded-lg", data: { turbo_frame: "modal"} do %>
+          <div class="inline-flex flex-shrink-0 items-center justify-center h-16 w-16 text-dark-purple bg-light-purple rounded-full mr-6 ">
             <%= svg_icon('departments', xmlns: 'http://www.w3.org/2000/svg', viewBox: '0 0 24 24', fill: 'currentColor', class: 'w-8 h-8', aria:{hidden:true}) %>
           </div>
           <article>

--- a/app/views/departments/show.html.erb
+++ b/app/views/departments/show.html.erb
@@ -1,27 +1,29 @@
 <%= turbo_frame_tag "modal" do %>
-  	<div id="overlay" class="fixed inset-0 z-10" data-controller="modal" data-modal-target="frame">
-		<dialog  class="modal bg-transparent" data-modal-target="modal">
-			<header>
-				<button type="button" class="sm:mx-0 w-full text-white font-wold text-xl flex justify-end py-3 my-3" data-action="click->modal#close">
-					<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-8 h-8">
-						<path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
-					</svg>
-				</button>
-			</header>
-			<div id="teams" class="h-full overflow-scroll">
-				<% if @department.teams.empty? %>
-					<p class="uppercase text-start text-white font-bold text-xl">There is not team associated to this departement!</p>
-				<% else %>
-					<p class="uppercase text-start text-white font-bold text-xl"><%= @department.teams.count %> teams in <%= @department.name %></p>
-					<div  class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-					<% @department.teams.each do |t| %>
-						<article class="rounded-full bg-dark-purple text-white w-48 h-48 flex align-center justify-center items-center my-3 mx-3">
-							<p class="text-xl font-semibold"><%= link_to t.name, department_team_path(@department.id, t) , data: { turbo_frame: "_top" }  %></p>
-						</article>
-					<% end %>
-					</div>
-				<% end %>
-			</div>
-		</dialog>
-	<div>
+  <div id="overlay" class="fixed inset-0 z-10" data-controller="modal" data-modal-target="frame">
+    <dialog class="modal bg-transparent" data-modal-target="modal">
+      <header>
+        <button type="button" class="sm:mx-0 w-full text-white font-wold text-xl flex justify-end py-3 px-6 my-3" data-action="click->modal#close">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-8 h-8">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </header>
+      <div id="teams" class="h-full overflow-scroll">
+        <% if @department.teams.empty? %>
+          <p class="uppercase text-start text-white font-bold text-xl md:text-2xl lg:text-3xl">There is no team associated with this department!</p>
+        <% else %>
+          <p class="uppercase text-start text-white font-bold text-xl md:text-2xl lg:text-3xl my-6"><%= @department.teams.count %> teams in <%= @department.name %></p>
+          <div class="flex justify-center">
+            <div class="flex flex-wrap justify-center gap-4 max-w-screen-lg ">
+              <% @department.teams.each do |t| %>
+                <article class="rounded-full bg-dark-purple text-white w-48 h-48 flex items-center justify-center my-3 mx-3">
+                  <p class="text-xl font-semibold"><%= link_to t.name, department_team_path(@department.id, t), data: { turbo_frame: "_top" } %></p>
+                </article>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </dialog>
+  </div>
 <% end %>


### PR DESCRIPTION
Add shadow effects to teams' containers
Update team display to use flexbox instead of grid for better centering.
Add responsive design to ensure teams are displayed in a column on mobile screens.
