### PR TITLE
feat(dashboard): fix validation when new manager only one per team

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -22,6 +22,7 @@ class TeamsController < ApplicationController
     @team = Team.new(team_params)
     respond_to do |format|
       if @team.save
+        @team.update_leader_roles(@team.user_id)
         format.html { redirect_to departments_path, notice: "Team was successfully created." }
         format.turbo_stream
       else

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -4,12 +4,20 @@ class Team < ApplicationRecord
     belongs_to :leader, class_name: 'Employee', foreign_key: 'user_id', optional: true
 
     validates :name, uniqueness: true
-
+    validate :unique_manager_per_team
 
     def update_leader_roles(new_leader_id, previous_leader_id = nil)
         User.find(new_leader_id).update(role: 'manager')
         if previous_leader_id && previous_leader_id != new_leader_id
           User.find(previous_leader_id).update(role: 'standard')
+        end
+    end
+    
+    private
+
+    def unique_manager_per_team
+        if Team.where(user_id: leader) .exists? && user_id != self.user_id
+          errors.add(:user_id, 'is already a manager of another team')
         end
     end
 end

--- a/app/views/teams/_form.html.erb
+++ b/app/views/teams/_form.html.erb
@@ -1,4 +1,14 @@
 <%= simple_form_for @team, html: { class: " p-2 mt-3"}, data: { turbo: false } do |f| %>
+  <% if @team.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(@team.errors.count, "error") %> prohibited this team from being saved:</h2>
+      <ul>
+        <% @team.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
   <form>
     <fieldset class="form-inputs">
       <%= f.input :name, input_html: { autocomplete: false }, label_html: { class: 'text-base font-medium py-2'}  %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,7 +15,6 @@ Department.delete_all
 
 puts "🌱 Seeding..."
 
-
 # Create Departments
 Department.create(name: 'TBD')
 10.times { Department.create(name: Faker::Company.department) }
@@ -47,7 +46,7 @@ puts "#{Position.count} positions have been created."
     email: "admin@admin.org",
     password: 'password',
     password_confirmation: 'password', 
-    role: 2
+    role: 'admin'
   )
    Employee.create!(
     first_name: Faker::Name.first_name,


### PR DESCRIPTION
Create two validation for creating and updating team : unique manager per team, one manager user per team. 
