### PR TITLE
Fix: refactor manager display in dashboard

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -4,9 +4,12 @@ class PagesController < ApplicationController
       @departments = Department.all.order('name ASC')
       @teams = Team.all.order('name ASC').excluding(@tbd_team)
       @employees = Employee.all.order('last_name ASC').excluding(@tbd_employees)
-      @managers = Employee.joins(:team).where.not(teams: {user_id: nil}).order('employees.last_name ASC')
+      manager_user_ids = Team.pluck(:user_id).uniq
+      @managers_without_team = Employee.joins(:user).where(users: { role: User.roles[:manager] }).where.not(user_id: manager_user_ids).order('employees.last_name ASC')
+      @managers =  Employee.joins(:team).where(teams: { user_id: Employee.select(:user_id) }).order('employees.last_name ASC')
       @employee = Employee.new
       @tbd_employees = Employee.joins(:position, :team).where("positions.name = 'TBD' OR teams.name = 'TBD'")
       @tbd_team = Team.where(name: 'TBD')
+      @teams_without_manager = Team.where(user_id: nil).excluding(@tbd_team)
     end
 end

--- a/app/views/pages/dashboard.html.erb
+++ b/app/views/pages/dashboard.html.erb
@@ -109,13 +109,14 @@
           </ul>
         </section>
       </article>
-      <% if @tbd_employees.present? || @tbd_dpt.present?%>
+      <% if @tbd_employees.present? || @teams_without_manager.present? || @managers_without_team.present? %>
         <article class="row-span-3 bg-white shadow-lg hover:shadow-2xl drop-shadow-xl rounded-lg">
           <header class="flex items-center justify-between px-6 py-5 font-semibold border-b border-gray-100">
             <h3 class="font-semibold">FOR ACTION - Information to be defined</h3>
           </header>
           <section class="overflow-y-auto" style="max-height: 24rem;">
             <ul class="p-6 space-y-6">
+              <h3 class="font-medium underline underline-offset-8">Employees with no team</h3>
               <% @tbd_employees.each do |employee| %>
                 <li class="flex items-center">
                   <figure class="h-10 w-10 mr-3 bg-gray-100 rounded-full overflow-hidden">
@@ -131,6 +132,46 @@
               <% end %>
             </ul>
           </section>
+          <% if @managers_without_team.present?%>
+            <section class="overflow-y-auto" style="max-height: 24rem;">
+              <ul class="p-6 space-y-6">
+              <h3 class="font-medium underline underline-offset-8">Managers without team</h3>
+                <% @managers_without_team.each do |employee| %>
+                  <li class="flex items-center">
+                    <figure class="h-10 w-10 mr-3 bg-gray-100 rounded-full overflow-hidden">
+                      <%= image_tag(employee.avatar, class: "w-full h-full object-cover") %>
+                    </figure>
+                  <% if user_signed_in?%>
+                    <p class="flex-1 w-1/2 break-words text-gray-600"><%= link_to employee.fullname, employee_path(employee) %></p>
+                  <% else %>
+                    <p class="flex-1 w-1/2 break-words text-gray-600"><a href="#" onclick="showPopup(); return false;"><%= employee.fullname %></a></p>                
+                  <% end %>
+                    <p class="flex-1 w-1/2 break-words text-end  ml-auto font-semibold"><%= employee.department.name %></p>
+                  </li>
+                <% end %>
+              </ul>
+            </section>
+          <% end %>
+          <% if @teams_without_manager.present?%>
+            <section class="overflow-y-auto" style="max-height: 24rem;">
+              <ul class="p-6 space-y-6">
+              <h3 class="font-medium underline underline-offset-8">Teams without manager</h3>
+                <% @teams_without_manager.each do |no_manager_team| %>
+                  <li class="flex items-center">
+                  <% if user_signed_in?%>
+                    <p class="flex-1 w-1/2 break-words text-gray-600"><%= link_to no_manager_team.name, department_team_path(no_manager_team.department, no_manager_team) %></p>
+                  <% else %>
+                    <p class="flex-1 w-1/2 break-words text-gray-600"><a href="#" onclick="showPopup(); return false;"><%= no_manager_team.name %></a></p>                
+                  <% end %>
+                    <p class="flex-1 w-1/2 break-words text-end  ml-auto font-semibold"><%= no_manager_team.department.name %></p>
+                  </li>
+                <% end %>
+              </ul>
+            </section>
+          
+          <% end %>
+          
+          <% console%>
         </article>
       <% end %>
     </section>


### PR DESCRIPTION
Refactor managers displaying to list users with manager role.
Create two new queries to list teams without manager and managers without team. 
Styling "for actions" box.
